### PR TITLE
Ignore some special and readonly linux file systems

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -790,10 +790,25 @@ impl CPUTimeApp {
         self.disk_total = 0;
         self.disks.clear();
 
+        static IGNORED_FILE_SYSTEMS: &[&[u8]] = &[
+            b"sysfs",
+            b"proc",
+            b"tmpfs",
+            b"cgroup",
+            b"cgroup2",
+            b"pstore",
+            b"squashfs",
+            b"iso9660",
+        ];
+
         for d in self.system.get_disks().iter() {
             let name = d.get_name().to_string_lossy();
             let mp = d.get_mount_point().to_string_lossy();
             if cfg!(target_os = "linux") {
+                let fs = d.get_file_system();
+                if IGNORED_FILE_SYSTEMS.iter().find(|ignored| &fs == *ignored).is_some() {
+                    continue;
+                }
                 if mp.starts_with("/sys") ||
                 mp.starts_with("/proc") ||
                 mp.starts_with("/run") ||


### PR DESCRIPTION
[Snaps](https://snapcraft.io) are packaged as `squashfs` objects, and then mounted (usually under `/snap`). Since this is a fixed file system, it will always show up as having 0% free space in zenith, so I propose it should be ignored.

Similarly, mounted iso images should be ignored.

This commit does not check mountpoints, but instead checks the filesystem reported by sysinfo. This also broadens compatibility with distros such as GoboLinux, which do not mount the special file systems in the usual places.

Before:
![image](https://user-images.githubusercontent.com/24556329/78830335-7200fa00-79f0-11ea-8024-34aa5b0c5f99.png)

After:
![image](https://user-images.githubusercontent.com/24556329/78830400-8cd36e80-79f0-11ea-9bf4-7b42ae5e00da.png)