### PR TITLE
Follow XDG Base Directory Specification

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,9 +189,9 @@ fn validate_height(arg: String) -> Result<(), String> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let default_db_path = dirs::home_dir()
+    let default_db_path = dirs::cache_dir()
         .unwrap_or(Path::new("./").to_owned())
-        .join(".zenith");
+        .join("zenith");
     let default_db_path = default_db_path
         .to_str()
         .expect("Couldn't set default db path");


### PR DESCRIPTION
Fixes #24

Instead of always using a .zenith directory in $HOME, we should be
using a directory designed to be used for cache.

I assume the files zenith creates are cache, because even the
.configuration file is autogenerated and doesn't actually contain any
configuration, only version information (AFAICS).