### PR TITLE
Use lockfile as pidfile to recover smoothly after process is killed

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,9 @@
  */
 use crate::constants::DEFAULT_TICK;
 use signal_hook::{iterator::Signals, SIGABRT, SIGINT, SIGTERM};
-use std::io;
+use std::fs::{remove_file, File};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
@@ -124,4 +126,57 @@ impl Events {
     pub fn next(&self) -> Result<Event<Key>, mpsc::RecvError> {
         self.rx.recv()
     }
+}
+
+/// Keeps a file open exclusively
+/// Removes the file when dropped
+pub struct Lockfile {
+    file: File,
+    path: PathBuf,
+}
+
+impl Lockfile {
+    /// Tries to open the file creating if it does not exist
+    /// Fails if zenith is already running using the same lockfile
+    pub async fn new(main_pid: u32, path: &Path) -> Option<Self> {
+        if is_zenith_running(path).await {
+            return None;
+        }
+
+        let mut file = File::create(path).ok()?;
+
+        file.write_all(main_pid.to_string().as_bytes()).ok()?;
+
+        Some(Self {
+            file,
+            path: path.into(),
+        })
+    }
+}
+
+impl Drop for Lockfile {
+    fn drop(&mut self) {
+        debug!("Removing Lock");
+        let res = remove_file(&self.path);
+        if let Err(e) = res {
+            error!(
+                "Error deleting lockfile: path={}, error={:?}",
+                self.path.display(),
+                e
+            );
+        }
+    }
+}
+
+async fn is_zenith_running(path: &Path) -> bool {
+    name_of_process_for_pidfile(path)
+        .await
+        .map_or(false, |name| name == "zenith")
+}
+
+async fn name_of_process_for_pidfile(path: &Path) -> Option<String> {
+    let data = std::fs::read_to_string(path).ok()?;
+    let pid: i32 = data.parse().ok()?;
+    let process = heim::process::get(pid).await.ok()?;
+    process.name().await.ok()
 }


### PR DESCRIPTION
Fixes #34 

This writes the pid of the main thread in the lockfile.

At startup, if the lockfile exists, instead of aborting directly, zenith checks if a process with that pid exists and has the same name. It halts with the previous error only if that appears to be running.

Otherwise, the assumption is that zenith must have been killed unexpectedly (power loss, terminal session killed, etc), rewrites the lockfile and proceeds as normal.