### PR TITLE
replace clap with gumdrop for cli args parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,15 +19,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "arc-swap"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,17 +51,6 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.6",
  "syn 1.0.27",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -181,30 +161,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
-]
-
-[[package]]
-name = "clap"
-version = "2.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -553,6 +509,26 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "gumdrop"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46571f5d540478cf70d2a42dd0d6d8e9f4b9cc7531544b93311e657b86568a0b"
+dependencies = [
+ "gumdrop_derive",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915ef07c710d84733522461de2a734d4d62a3fd39a4d4f404c2f385ef8618d05"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.6",
+ "syn 1.0.27",
+]
 
 [[package]]
 name = "heim"
@@ -1374,12 +1350,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
-
-[[package]]
 name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,15 +1392,6 @@ dependencies = [
  "once_cell",
  "rayon",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1575,12 +1536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version-sync"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,11 +1656,10 @@ dependencies = [
  "bincode",
  "byte-unit",
  "chrono",
- "clap",
- "crossterm",
  "dirs",
  "env_logger",
  "futures",
+ "gumdrop",
  "heim",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ num-derive = "0.3.0"
 num-traits = "0.2"
 heim = {version = "0.1.0-beta.1", features = ["full"]}
 futures = "^0.3.5"
-clap = "2.31.*"
+gumdrop = {version = "0.8", features = ["default_expr"]}
 chrono = "0.4.*"
 sysinfo = {git = "https://github.com/bvaisvil/sysinfo.git", branch="zenith_changes"}
 dirs = "2.0.*"

--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@ In zenith 'h' key will show this help:
 - [heim](https://github.com/heim-rs/heim)
 - [battery](https://github.com/svartalf/rust-battery)
 - [serde](https://github.com/serde-rs/serde)
-- [clap](https://github.com/clap-rs/clap)
+- [gumdrop](https://github.com/murarth/gumdrop)
 - [nvml-wrapper](https://github.com/Cldfire/nvml-wrapper)


### PR DESCRIPTION
This results in about 0.5M smaller binary (4.5MiB down from 5.1MiB with rustc 1.46 nightly), fewer dependencies, and a slightly faster compile