### PR TITLE
Fix lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1665,7 @@ dependencies = [
  "bincode",
  "byte-unit",
  "chrono",
+ "crossterm",
  "dirs",
  "env_logger",
  "futures",


### PR DESCRIPTION
My apologies, I made a mistake while merging the changes to Cargo.lock. Right now when building, cargo always add these back to the lockfile. Adding these back to make `--locked` builds work.