### PR TITLE
Add grid view for core usage

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -34,6 +34,7 @@ use tui::widgets::{BarChart, Block, Borders, List, Paragraph, Row, Sparkline, Ta
 use tui::Frame;
 
 const PROCESS_SELECTION_GRACE: Duration = Duration::from_millis(2000);
+const LEFT_PANE_WIDTH: u16 = 30u16;
 
 type ZBackend = CrosstermBackend<Stdout>;
 
@@ -468,7 +469,7 @@ fn render_net(
     let network_layout = Layout::default()
         .margin(0)
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(30), Constraint::Min(10)].as_ref())
+        .constraints([Constraint::Length(LEFT_PANE_WIDTH), Constraint::Min(10)].as_ref())
         .split(area);
     let net = Layout::default()
         .margin(1)
@@ -755,7 +756,7 @@ fn render_disk(
     let disk_layout = Layout::default()
         .margin(0)
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(30), Constraint::Min(10)].as_ref())
+        .constraints([Constraint::Length(LEFT_PANE_WIDTH), Constraint::Min(10)].as_ref())
         .split(layout);
     let area = Layout::default()
         .margin(1)
@@ -898,7 +899,7 @@ fn render_graphics(
     let gfx_layout = Layout::default()
         .margin(0)
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(30), Constraint::Min(10)].as_ref())
+        .constraints([Constraint::Length(LEFT_PANE_WIDTH), Constraint::Min(10)].as_ref())
         .split(layout);
     let area = Layout::default()
         .margin(1)
@@ -1199,7 +1200,7 @@ fn render_cpu(
     let cpu_layout = Layout::default()
         .margin(0)
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(30), Constraint::Min(10)].as_ref())
+        .constraints([Constraint::Length(LEFT_PANE_WIDTH), Constraint::Min(10)].as_ref())
         .split(area);
 
     let cpu_mem = Layout::default()
@@ -1209,7 +1210,7 @@ fn render_cpu(
         .split(cpu_layout[1]);
     render_cpu_histogram(&app, cpu_mem[0], f, zf, update_number, offset);
     render_memory_histogram(&app, cpu_mem[1], f, zf, update_number, offset);
-    render_cpu_bars(&app, cpu_layout[0], 30, f, &style);
+    render_cpu_bars(&app, cpu_layout[0], LEFT_PANE_WIDTH, f, &style);
 }
 
 fn filter_process_table(app: &CPUTimeApp, filter: &str) -> Vec<i32> {

--- a/src/render.rs
+++ b/src/render.rs
@@ -440,6 +440,15 @@ fn render_cpu_bars(
     let bar_gap: u16 = 1;
     let bars: Vec<(&str, u64)> = cpus.iter().map(|(p, u)| (p.as_str(), *u)).collect();
 
+    fn clamp_up(val: u16, upper: u16) -> u16 {
+        if val > upper {
+            upper
+        } else {
+            val
+        }
+    }
+    let max_bar_width = 3;
+
     if full_width <= width {
         // fits in one row
 
@@ -447,7 +456,7 @@ fn render_cpu_bars(
             .constraints(vec![Constraint::Percentage(100)])
             .split(area);
 
-        let bar_width = (width - (core_count - 1)) / core_count;
+        let bar_width = clamp_up((width - (core_count - 1)) / core_count, max_bar_width);
 
         BarChart::default()
             .data(bars.as_slice())
@@ -466,7 +475,7 @@ fn render_cpu_bars(
             .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
             .split(area);
 
-        let bar_width = (width * 2 - (core_count - 1)) / core_count;
+        let bar_width = clamp_up((width * 2 - (core_count - 1)) / core_count, max_bar_width);
 
         BarChart::default()
             .data(&bars[half..])


### PR DESCRIPTION
Intended to fix #39 

This changes the single and double row bar graph to always use a single column gap for readability, and also makes the bar width variable to fill the available space evenly.

The grid view displays core usages are green, and turns them red at above 90%. Suggestions also welcome for more space-efficient ways to display the core grid.

BIkeshedding on visuals encouraged :), since I didn't completely understand the intent behind the previous way bars were rendered.

Edit: new single row layout:
![image](https://user-images.githubusercontent.com/24556329/87252477-22611d00-c47c-11ea-8c3c-1274aeb1d774.png)