### PR TITLE
Add MEM utilization value in figures before the percentage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .git
+.idea
 target

--- a/src/render.rs
+++ b/src/render.rs
@@ -95,10 +95,15 @@ fn mem_title(app: &CPUTimeApp) -> String {
         None => String::from(""),
     };
 
+    // use padding in utilization string as per the size of total
+    let mem_tot_str = float_to_byte_string!(app.mem_total as f64, ByteUnit::KB);
+    let mem_util_str = float_to_byte_string!(app.mem_utilization as f64, ByteUnit::KB);
+    let mem_pad_len = mem_tot_str.len() - mem_util_str.len();
+    let mem_pad = if mem_pad_len > 0 { " ".repeat(mem_pad_len) } else { "".to_string() };
+
     format!(
-        "MEM [{}] Usage [{: >3}%] SWP [{}] Usage [{: >3}%] {:}",
-        float_to_byte_string!(app.mem_total as f64, ByteUnit::KB),
-        mem,
+        "MEM [{}] Usage [{}{} - {: >3}%] SWP [{}] Usage [{: >3}%] {:}",
+        mem_tot_str, mem_pad, mem_util_str, mem,
         float_to_byte_string!(app.swap_total as f64, ByteUnit::KB),
         swp,
         top_mem_proc

--- a/src/render.rs
+++ b/src/render.rs
@@ -95,22 +95,12 @@ fn mem_title(app: &CPUTimeApp) -> String {
         None => String::from(""),
     };
 
-    // use padding in utilization string as per the size of total
-    let mem_tot_str = float_to_byte_string!(app.mem_total as f64, ByteUnit::KB);
-    let mem_util_str = float_to_byte_string!(app.mem_utilization as f64, ByteUnit::KB);
-    let mem_pad_len = mem_tot_str.len() - mem_util_str.len();
-    let mem_pad = if mem_pad_len > 0 {
-        " ".repeat(mem_pad_len)
-    } else {
-        "".to_string()
-    };
-
     format!(
-        "MEM [{}] Usage [{}{} - {: >3}%] SWP [{}] Usage [{: >3}%] {:}",
-        mem_tot_str,
-        mem_pad,
-        mem_util_str,
+        "MEM [{} / {} - {:}%] SWP [{} / {} - {:}%] {:}",
+        float_to_byte_string!(app.mem_utilization as f64, ByteUnit::KB),
+        float_to_byte_string!(app.mem_total as f64, ByteUnit::KB),
         mem,
+        float_to_byte_string!(app.swap_utilization as f64, ByteUnit::KB),
         float_to_byte_string!(app.swap_total as f64, ByteUnit::KB),
         swp,
         top_mem_proc
@@ -971,10 +961,11 @@ fn render_graphics(
         .block(
             Block::default().title(
                 format!(
-                    "FB [{:3.0}%] MEM [{:} / {:}] {:} Pwr [{:} W / {:} W] Tmp [{:} C / {:} C]",
+                    "FB [{:3.0}%] MEM [{:} / {:} - {:}%] {:} Pwr [{:} W / {:} W] Tmp [{:} C / {:} C]",
                     gd.mem_utilization,
                     float_to_byte_string!(gd.used_memory as f64, ByteUnit::B),
                     float_to_byte_string!(gd.total_memory as f64, ByteUnit::B),
+                    percent_of(gd.used_memory, gd.total_memory) as u64,
                     fan,
                     gd.power_usage / 1000,
                     gd.max_power / 1000,

--- a/src/render.rs
+++ b/src/render.rs
@@ -99,11 +99,18 @@ fn mem_title(app: &CPUTimeApp) -> String {
     let mem_tot_str = float_to_byte_string!(app.mem_total as f64, ByteUnit::KB);
     let mem_util_str = float_to_byte_string!(app.mem_utilization as f64, ByteUnit::KB);
     let mem_pad_len = mem_tot_str.len() - mem_util_str.len();
-    let mem_pad = if mem_pad_len > 0 { " ".repeat(mem_pad_len) } else { "".to_string() };
+    let mem_pad = if mem_pad_len > 0 {
+        " ".repeat(mem_pad_len)
+    } else {
+        "".to_string()
+    };
 
     format!(
         "MEM [{}] Usage [{}{} - {: >3}%] SWP [{}] Usage [{: >3}%] {:}",
-        mem_tot_str, mem_pad, mem_util_str, mem,
+        mem_tot_str,
+        mem_pad,
+        mem_util_str,
+        mem,
         float_to_byte_string!(app.swap_total as f64, ByteUnit::KB),
         swp,
         top_mem_proc


### PR DESCRIPTION
I find it much more useful to see the numbers for memory utilization rather than just the percentage. This PR adds the value of used MEM before the percentage display. The result looks like: MEM [65.78GB] Usage [ 4.39GB -   6%] SWP [67.11GB] Usage [  0%]