### PR TITLE
Use percentages for relative heights of panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,14 +152,16 @@ FLAGS:
     -V, --version            Prints version information
 
 OPTIONS:
-    -c, --cpu-height <INT>        Height of CPU/Memory visualization. [default: 10]
+    -c, --cpu-height <INT>        Min Percent Height of CPU/Memory visualization. [default: 17]
         --db <STRING>             Database to use, if any. [default: ~/.zenith]
-    -d, --disk-height <INT>       Height of Disk visualization. [default: 10]
-    -n, --net-height <INT>        Height of Network visualization. [default: 10]
-    -p, --process-height <INT>    Min Height of Process Table. [default: 8]
+    -d, --disk-height <INT>       Min Percent Height of Disk visualization. [default: 17]
+    -n, --net-height <INT>        Min Percent Height of Network visualization. [default: 17]
+    -p, --process-height <INT>    Min Percent Height of Process Table. [default: 32]
     -r, --refresh-rate <INT>      Refresh rate in milliseconds. [default: 2000]
+    -g, --graphics-height <INT>   Min Percent Height of Graphics Card visualization. [default: 17]
 ```
 
+The graphics-height option only applies when NVIDIA GPU support has been enabled.
 
 Don't want a section? Remove it by setting the height to 0. 
 

--- a/src/graphics_nvidia.rs
+++ b/src/graphics_nvidia.rs
@@ -36,7 +36,7 @@ impl TryFrom<&Device<'_>> for GraphicsDevice {
             }
             Err(e) => error!("Failed Getting Memory Info {:?}", e),
         }
-        gd.name = d.name().unwrap_or(String::from(""));
+        gd.name = d.name().unwrap_or_default();
         gd.clock = d.clock_info(Clock::Graphics).unwrap_or(0);
         gd.max_clock = d.max_clock_info(Clock::Graphics).unwrap_or(0);
         gd.power_usage = d.power_usage().unwrap_or(0);
@@ -70,7 +70,7 @@ impl TryFrom<&Device<'_>> for GraphicsDevice {
             Err(e) => error!("Couldn't get utilization rates: {:?}", e),
         }
         match d.process_utilization_stats(None) {
-            Ok(ps) => gd.processes = ps.iter().map(|p| GraphicsDeviceProcess::from(p)).collect(),
+            Ok(ps) => gd.processes = ps.iter().map(GraphicsDeviceProcess::from).collect(),
             Err(_) => debug!(
                 "Couldn't retrieve process utilization stats for {:}",
                 gd.name

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,7 @@ fn create_geometry(
     }
     assert_eq!(sensor_height, 0); // not implemented
 
-    let num_sections = geometry.len();
-    if num_sections == 0 {
+    if geometry.is_empty() {
         exit_with_message!("All sections have size specified as zero!", 1);
     }
     // sum of minimum percentages should not exceed 100%

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -337,10 +337,8 @@ impl CPUTimeApp {
                     debug!("{:?}", t);
                     self.sensors.push(Sensor::from(t));
                 }
-            } else if cfg!(target_os = "macos") {
-                if t.get_label().contains("CPU") {
-                    self.sensors.push(Sensor::from(t));
-                }
+            } else if cfg!(target_os = "macos") && t.get_label().contains("CPU") {
+                self.sensors.push(Sensor::from(t));
             }
         }
     }

--- a/src/render.rs
+++ b/src/render.rs
@@ -67,21 +67,32 @@ macro_rules! float_to_byte_string {
     };
 }
 
-macro_rules! set_section_height {
+macro_rules! update_section_height {
     ($x:expr, $val:expr) => {
-        if $x + $val > 0 {
+        if $x + $val > 0.0 && $x + $val < 100.0 {
             $x += $val;
+            true
+        } else {
+            false
         }
     };
 }
 
 #[derive(FromPrimitive, PartialEq, Copy, Clone)]
-enum Section {
+pub enum Section {
     CPU = 0,
     Network = 1,
     Disk = 2,
     Graphics = 3,
     Process = 4,
+}
+
+pub fn sum_section_heights(geometry: &Vec<(Section, f64)>) -> f64 {
+    let mut sum = 0.0;
+    for section in geometry {
+        sum += section.1;
+    }
+    sum
 }
 
 fn mem_title(app: &CPUTimeApp) -> String {
@@ -1376,22 +1387,110 @@ fn render_help(area: Rect, f: &mut Frame<'_, ZBackend>) {
         .render(f, help_layout[1]);
 }
 
+/// current size of the terminal returned as (columns, rows)
+fn terminal_size() -> (u16, u16) {
+    crossterm::terminal::size().expect("Failed to get terminal size")
+}
+
+/// ceil to nearest upper even number
+macro_rules! ceil_even {
+    ($x:expr) => {
+        ($x + 1) / 2 * 2
+    };
+}
+
+/// Convert percentage heights to length constraints. This is done since sections other
+/// than process have two sub-parts and should be of even height.
+fn eval_constraints(
+    section_geometry: &Vec<(Section, f64)>,
+    height: u16,
+    borrowed: &mut bool,
+) -> Vec<Constraint> {
+    debug!("Get Constraints");
+    let mut constraints = vec![Constraint::Length(1)];
+    let avail_height = height as i32 - 1;
+    let mut process_index = -1;
+    let mut max_others = 0;
+    let mut max_others_index = -1;
+    let mut sum_others = 0;
+    let num_sections = section_geometry.len();
+    // each section should have a height of at least 2 rows
+    let mut max_section_height = avail_height - num_sections as i32 * 2;
+    // process section is at least 4 rows high
+    if section_geometry.iter().any(|s| s.0 == Section::Process) {
+        max_section_height -= 2;
+    }
+    // convert percentage heights to length constraints and apply additional
+    // criteria that height should be even number for non-process sections
+    for section_index in 0..num_sections {
+        let section = section_geometry[section_index];
+        let required_height = section.1 * avail_height as f64 / 100.0;
+        // ensure max_section_height is at least 2 after every recalculation
+        max_section_height = max_section_height.max(2);
+        if section.0 == Section::Process {
+            process_index = section_index as i32;
+            constraints.push(Constraint::Min(4));
+        } else {
+            // round to nearest even size for the two sub-parts in each section display
+            let section_height =
+                max_section_height.min(ceil_even!(required_height.floor().max(1.0) as i32));
+            sum_others += section_height;
+            // adjust max_section_height for subsequent sections
+            max_section_height -= section_height - 2;
+            if section_height >= max_others {
+                max_others = section_height;
+                max_others_index = section_index as i32;
+            }
+            constraints.push(Constraint::Length(section_height as u16));
+        }
+    }
+    // remaining is what will be actually used for process section but if its too small (due to
+    // rounding to even heights for other sections), then borrow rows from the largest section
+    if process_index != -1 {
+        let process_height = avail_height - sum_others;
+        if process_height < 4 && max_others > 4 {
+            let borrow = ceil_even!(4 - process_height).min(max_others - 4);
+            // (max_others - borrow) will be >= 4 due to the min() above so cast to u16 is safe
+            constraints[max_others_index as usize + 1] =
+                Constraint::Length((max_others - borrow) as u16);
+            constraints[process_index as usize + 1] =
+                Constraint::Min((process_height + borrow) as u16);
+            *borrowed = true;
+        } else {
+            constraints[process_index as usize + 1] = Constraint::Min(process_height as u16);
+        }
+    }
+
+    constraints
+}
+
+fn get_constraints(section_geometry: &Vec<(Section, f64)>, height: u16) -> Vec<Constraint> {
+    let mut borrowed = false;
+    eval_constraints(section_geometry, height, &mut borrowed)
+}
+
 pub struct TerminalRenderer {
     terminal: Terminal<CrosstermBackend<Stdout>>,
     app: CPUTimeApp,
     events: Events,
     process_table_row_start: usize,
     gfx_device_index: usize,
-    cpu_height: i16,
-    net_height: i16,
-    disk_height: i16,
-    process_height: i16,
-    graphics_height: i16,
-    _sensor_height: i16,
+    /// Index in the vector below is "order" on the screen starting from the top
+    /// (usually CPU) while value is the section it belongs to and its current height (as %).
+    /// Currently all sections are stacked on top of one another horizontally and
+    /// occupy entire width of the screen but this may change going forward. For the case
+    /// where there are multiple sections stacked vertically, the "order" can have the
+    /// convention of top-bottom and left-right in each horizontal layer and the width of
+    /// each section be tracked below. For more generic positioning (e.g. sections cutting
+    /// across others vertically), this mapping needs to also include the position of
+    /// top-left corner of the section. In that case the only significance that the
+    /// "order" will have is the sequence in which the TAB key will shift focus
+    /// among the sections.
+    section_geometry: Vec<(Section, f64)>,
     zoom_factor: u32,
     update_number: u32,
     hist_start_offset: usize,
-    selected_section: Section,
+    selected_section_index: usize,
     constraints: Vec<Constraint>,
     process_message: Option<String>,
     show_help: bool,
@@ -1405,26 +1504,9 @@ pub struct TerminalRenderer {
 impl<'a> TerminalRenderer {
     pub fn new(
         tick_rate: u64,
-        cpu_height: i16,
-        net_height: i16,
-        disk_height: i16,
-        process_height: i16,
-        sensor_height: i16,
-        graphics_height: i16,
+        section_geometry: &Vec<(Section, f64)>,
         db_path: Option<PathBuf>,
     ) -> TerminalRenderer {
-        debug!("Setup Constraints");
-        let mut constraints = vec![
-            Constraint::Length(1),
-            Constraint::Length(cpu_height as u16),
-            Constraint::Length(net_height as u16),
-            Constraint::Length(disk_height as u16),
-            Constraint::Length(graphics_height as u16),
-        ];
-        if process_height > 0 {
-            constraints.push(Constraint::Min(process_height as u16));
-        }
-
         debug!("Create Metrics App");
         let app = CPUTimeApp::new(Duration::from_millis(tick_rate), db_path);
         debug!("Create Event Loop");
@@ -1438,21 +1520,18 @@ impl<'a> TerminalRenderer {
             Terminal::new(backend).expect("Couldn't create new terminal with backend");
         terminal.hide_cursor().ok();
 
+        let constraints = get_constraints(&section_geometry, terminal_size().1);
         TerminalRenderer {
             terminal,
             app,
             events,
             process_table_row_start: 0,
             gfx_device_index: 0,
-            cpu_height,
-            net_height,
-            disk_height,
-            process_height,
-            graphics_height,
-            _sensor_height: sensor_height, // unused at the moment
+            section_geometry: section_geometry.to_vec(),
             zoom_factor: 1,
             update_number: 0,
-            selected_section: Section::Process,
+            // select the last section by default (normally should be Process)
+            selected_section_index: section_geometry.len() - 1,
             constraints,
             process_message: None,
             hist_start_offset: 0,
@@ -1465,39 +1544,48 @@ impl<'a> TerminalRenderer {
         }
     }
 
-    async fn set_constraints(&mut self) {
-        let mut constraints = vec![
-            Constraint::Length(1),
-            Constraint::Length(self.cpu_height as u16),
-            Constraint::Length(self.net_height as u16),
-            Constraint::Length(self.disk_height as u16),
-            Constraint::Length(self.graphics_height as u16),
-        ];
-        if self.process_height > 0 {
-            constraints.push(Constraint::Min(self.process_height as u16));
+    /// Update section height by given delta value in number of rows.
+    /// This transforms the value in terms of percentage and reduces the
+    /// other section percentages proportionally. By this it means that
+    /// larger sections will be reduced more while smaller ones will be
+    /// reduced less. Overall the total percentage heights in section_geometry
+    /// should always be close to 100%.
+    async fn update_section_height(&mut self, delta: i16) {
+        // convert val to percentage
+        let (_, height) = terminal_size();
+        let avail_height = (height - 1) as f64;
+        let mut val = delta as f64 * 100.0 / avail_height;
+        let selected_index = self.selected_section_index;
+        let mut new_geometry = self.section_geometry.to_vec();
+        if update_section_height!(new_geometry[selected_index].1, val) {
+            // reduce proportionately from other sections if the value was updated
+            let rest = 100.0 - new_geometry[selected_index].1 + val;
+            for section_index in 0..new_geometry.len() {
+                if section_index != selected_index {
+                    let change = new_geometry[section_index].1 * val / rest;
+                    // abort if limits are exceeded
+                    if !update_section_height!(new_geometry[section_index].1, -change) {
+                        val = 0.0; // abort changes
+                        break;
+                    }
+                }
+            }
+            if val != 0.0 {
+                let mut borrowed = false;
+                let new_constraints = eval_constraints(&new_geometry, height, &mut borrowed);
+                // abort if process section became too small and borrowed from others
+                if !borrowed {
+                    let new_sum_heights = sum_section_heights(&new_geometry);
+                    assert!(new_sum_heights >= 99.9 && new_sum_heights <= 100.1);
+                    self.section_geometry = new_geometry;
+                    self.constraints = new_constraints;
+                }
+            }
         }
-        self.constraints = constraints;
     }
 
-    async fn set_section_height(&mut self, val: i16) {
-        match self.selected_section {
-            Section::CPU => set_section_height!(self.cpu_height, val),
-            Section::Disk => set_section_height!(self.disk_height, val),
-            Section::Network => set_section_height!(self.net_height, val),
-            Section::Graphics => set_section_height!(self.graphics_height, val),
-            Section::Process => set_section_height!(self.process_height, val),
-        }
-        self.set_constraints().await;
-    }
-
-    fn current_section_height(&mut self) -> i16 {
-        match self.selected_section {
-            Section::CPU => self.cpu_height,
-            Section::Disk => self.disk_height,
-            Section::Network => self.net_height,
-            Section::Graphics => self.graphics_height,
-            Section::Process => self.process_height,
-        }
+    fn selected_section(&self) -> Section {
+        self.section_geometry[self.selected_section_index].0
     }
 
     pub async fn start(&mut self) {
@@ -1505,12 +1593,12 @@ impl<'a> TerminalRenderer {
         loop {
             let app = &self.app;
             let pst = &self.process_table_row_start;
-            let process_height = &self.process_height;
             let mut width: u16 = 0;
             let mut process_table_height: u16 = 0;
             let zf = &self.zoom_factor;
             let constraints = &self.constraints;
-            let selected = &self.selected_section;
+            let geometry = &self.section_geometry;
+            let selected = self.selected_section();
             let process_message = &self.process_message;
             let offset = &self.hist_start_offset;
             let un = &self.update_number;
@@ -1549,48 +1637,60 @@ impl<'a> TerminalRenderer {
                             .split(f.size());
 
                         render_top_title_bar(app, v_sections[0], &mut f, zf, offset);
-                        render_cpu(app, v_sections[1], &mut f, zf, un, offset, selected);
-                        render_net(&app, v_sections[2], &mut f, zf, un, offset, selected);
-                        render_disk(&app, v_sections[3], &mut f, zf, un, offset, selected);
-                        render_graphics(
-                            &app,
-                            v_sections[4],
-                            &mut f,
-                            zf,
-                            un,
-                            gfx_device_index,
-                            offset,
-                            selected,
-                        );
-
-                        if *process_height > 0 {
-                            if let Some(area) = v_sections.last() {
-                                if app.selected_process.is_none() {
-                                    highlighted_process = render_process_table(
-                                        &app,
-                                        &process_table,
-                                        width,
-                                        *area,
-                                        *pst,
-                                        &mut f,
-                                        selected,
-                                        show_paths,
-                                        show_find,
-                                        filter,
-                                        highlighted_row,
-                                    );
-                                    if area.height > 4 {
-                                        // account for table border & margins.
-                                        process_table_height = area.height - 5;
+                        for section_index in 0..geometry.len() {
+                            let v_section = v_sections[section_index + 1];
+                            match geometry[section_index].0 {
+                                Section::CPU => {
+                                    render_cpu(app, v_section, &mut f, zf, un, offset, &selected)
+                                }
+                                Section::Network => {
+                                    render_net(&app, v_section, &mut f, zf, un, offset, &selected)
+                                }
+                                Section::Disk => {
+                                    render_disk(&app, v_section, &mut f, zf, un, offset, &selected)
+                                }
+                                Section::Graphics => render_graphics(
+                                    &app,
+                                    v_section,
+                                    &mut f,
+                                    zf,
+                                    un,
+                                    gfx_device_index,
+                                    offset,
+                                    &selected,
+                                ),
+                                Section::Process => {
+                                    if app.selected_process.is_none() {
+                                        highlighted_process = render_process_table(
+                                            &app,
+                                            &process_table,
+                                            width,
+                                            v_section,
+                                            *pst,
+                                            &mut f,
+                                            &selected,
+                                            show_paths,
+                                            show_find,
+                                            filter,
+                                            highlighted_row,
+                                        );
+                                        if v_section.height > 4 {
+                                            // account for table border & margins.
+                                            process_table_height = v_section.height - 5;
+                                        }
+                                    } else if app.selected_process.is_some() {
+                                        render_process(
+                                            &app,
+                                            v_section,
+                                            &mut f,
+                                            &selected,
+                                            process_message,
+                                        );
                                     }
-                                } else if app.selected_process.is_some() {
-                                    render_process(&app, *area, &mut f, selected, process_message);
                                 }
                             }
                         }
                     }
-
-                    //render_sensors(&app, sensor_layout, &mut f, zf);
                 })
                 .expect("Could not draw frame.");
 
@@ -1618,6 +1718,10 @@ impl<'a> TerminalRenderer {
     ) -> Action {
         let input = match self.events.next().expect("No new event.") {
             Event::Input(input) => input,
+            Event::Resize(_, height) => {
+                self.constraints = get_constraints(&self.section_geometry, height);
+                return Action::Continue;
+            }
             Event::Tick => {
                 debug!("Event Tick");
 
@@ -1687,11 +1791,12 @@ impl<'a> TerminalRenderer {
     }
 
     fn view_up(&mut self, process_table: &[i32], delta: usize) {
-        if self.selected_section == Section::Graphics {
+        let selected = self.selected_section();
+        if selected == Section::Graphics {
             if self.gfx_device_index > 0 {
                 self.gfx_device_index -= 1;
             }
-        } else if self.selected_section == Section::Process {
+        } else if selected == Section::Process {
             if self.app.selected_process.is_some() || process_table.is_empty() {
                 return;
             }
@@ -1710,11 +1815,12 @@ impl<'a> TerminalRenderer {
 
     fn view_down(&mut self, process_table: &[i32], process_table_height: usize, delta: usize) {
         use std::cmp::min;
-        if self.selected_section == Section::Graphics {
+        let selected = self.selected_section();
+        if selected == Section::Graphics {
             if self.gfx_device_index < self.app.gfx_devices.len() - 1 {
                 self.gfx_device_index += 1;
             }
-        } else if self.selected_section == Section::Process {
+        } else if selected == Section::Process {
             if self.app.selected_process.is_some() || process_table.is_empty() {
                 return;
             }
@@ -1769,24 +1875,6 @@ impl<'a> TerminalRenderer {
                 None => self.show_find = false,
             },
             _ => {}
-        }
-    }
-
-    fn advance_to_next_section(&mut self) {
-        if self.cpu_height > 0
-            || self.net_height > 0
-            || self.disk_height > 0
-            || self.graphics_height > 0
-            || self.process_height > 0
-        {
-            let mut i = self.selected_section as u32 + 1;
-            if i > 4 {
-                i = 0;
-            }
-            self.selected_section = FromPrimitive::from_u32(i).unwrap_or(Section::CPU);
-            if self.current_section_height() == 0 {
-                self.advance_to_next_section();
-            }
         }
     }
 
@@ -1877,13 +1965,14 @@ impl<'a> TerminalRenderer {
                 };
             }
             Key::Tab => {
-                self.advance_to_next_section();
+                self.selected_section_index =
+                    (self.selected_section_index + 1) % self.section_geometry.len();
             }
             Key::Char('m') => {
-                self.set_section_height(-2).await;
+                self.update_section_height(-2).await;
             }
             Key::Char('e') => {
-                self.set_section_height(2).await;
+                self.update_section_height(2).await;
             }
             Key::Char('`') => {
                 self.zoom_factor = 1;

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 pub enum Event<I> {
     Input(I),
+    Resize(u16, u16),
     Tick,
     Save,
     Terminate,
@@ -55,8 +56,12 @@ impl Events {
         let input_handle = {
             let tx = tx.clone();
             thread::spawn(move || loop {
-                if let CEvent::Key(key) = event::read().expect("Couldn't read event") {
-                    tx.send(Event::Input(key)).expect("Couldn't send event.");
+                match event::read().expect("Couldn't read event") {
+                    CEvent::Key(key) => tx.send(Event::Input(key)).expect("Couldn't send event."),
+                    CEvent::Resize(cols, rows) => tx
+                        .send(Event::Resize(cols, rows))
+                        .expect("Couldn't send event."),
+                    _ => (), // ignore
                 }
             })
         };


### PR DESCRIPTION
* To avoid cutting off panels altogether use percentages for the various panels instead of fixed heights for all but process panel.
* By default the process panel occupies 10% more space than other non-zero ones.
* use a vector to track sections and their heights
  - use an ordered vector to track the geometry of each section (height for now) instead of using separate variables for each section
  - convert the height percentages into lengths before applying as constraints
  - catch terminal resize event and recalculate the lengths as per percentages
  - apply the constraints that non-process sections should have even number of rows, each section should be at least size 2, process section should have at least size 4; this is after accounting for all other section heights
  - pass a flag to check if process table had to "borrow" from others to keep its minimum size and abort size change due to e/m keys if that is the case