### PR TITLE
Change NVIDIA check from nvidia-uvm to nvidiactl

### DIFF
--- a/assets/zenith-static.sh
+++ b/assets/zenith-static.sh
@@ -7,7 +7,7 @@ absPath() {
 scriptPath="`absPath "$0"`"
 scriptDir="`dirname "$scriptPath"`"
 
-if test -r /dev/nvidia-uvm && "$scriptDir/zenith-exec/zenith-libnvidia-detect"; then
+if test -r /dev/nvidiactl && "$scriptDir/zenith-exec/zenith-libnvidia-detect"; then
   exec "$scriptDir/zenith-exec/nvidia/zenith" "$@"
 else
   exec "$scriptDir/zenith-exec/base/zenith" "$@"

--- a/assets/zenith.sh
+++ b/assets/zenith.sh
@@ -2,7 +2,7 @@
 
 PREFIX=/usr/local
 
-if test -r /dev/nvidia-uvm && "$PREFIX/lib/zenith/zenith-libnvidia-detect"; then
+if test -r /dev/nvidiactl && "$PREFIX/lib/zenith/zenith-libnvidia-detect"; then
   exec "$PREFIX/lib/zenith/nvidia/zenith" "$@"
 else
   exec "$PREFIX/lib/zenith/base/zenith" "$@"


### PR DESCRIPTION
Noticed that /dev/nvidia-uvm is sometimes not present if no app has been used that uses those APIs (CUDA?) and loads the nvidia-uvm kernel module. This trivial change is to check for /dev/nvidiactl instead which should always be present in a working NVIDIA driver on linux.