### PR TITLE
Update README with Arch build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@
 
 Download one of the compiled [releases](https://github.com/bvaisvil/zenith/releases).
 
+### Arch Linux
+
+Three packages for zenith are available in AUR: zenith, zenith-git and zenith-bin
+
+The last one uses the statically linked binary and is not recommended unless you want to completely avoid building the package. The first two depend on rust/cargo and its recommended to install the rustup package from AUR instead of the rust package from official repositories. This allows for easy installation of rust components as per what rust officially documents. You will need to install a toolchain separately with rustup so use something like:
+
+```bash
+yay -S rustup
+rustup toolchain install stable
+rustup default stable
+```
+
+Change the 'stable' toolchain above to beta/nightly/... if you have some specific preference. After this install the zenith or zenith-git package (latter will always track the latest git revision): ```yay -S zenith```
+
 ### Homebrew
 
 ```bash

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-zenith (0.10.1~1) unstable; urgency=medium
+zenith (0.10.1-1) unstable; urgency=medium
 
   * Initial deb package release.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+zenith (0.11.0-1) unstable; urgency=medium
+
+  * Updated to new upstream release.
+
+ -- Sumedh Wale <swale@gmail.com>  Wed, 21 Oct 2020 11:17:25 +0530
+
 zenith (0.10.1-1) unstable; urgency=medium
 
   * Initial deb package release.


### PR DESCRIPTION
Separated out Arch Linux instructions and version change in debian/changelog from #77