### PR TITLE
Makefile: build platform-specific binary by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all base clean install uninstall linux-static
+.PHONY: platform all base nvidia clean install install-base install-nvidia install-both install-desktop uninstall linux-static
 
 DESTDIR =
 PREFIX = /usr/local
@@ -19,16 +19,17 @@ CC_STATIC_TARGET = x86_64_unknown_linux_musl
 STATIC_DIR = build/static-bundle
 STATIC_EXEC_DIR = $(STATIC_DIR)/zenith-exec
 
+
+platform:
+	@if [ $(BUILD_NVIDIA) = true ] && sh assets/zenith-libnvidia-detect.sh; then \
+	  $(MAKE) nvidia; \
+	else \
+	  $(MAKE) base; \
+	fi
+
 all: base
 	@if [ $(BUILD_NVIDIA) = true ] && sh assets/zenith-libnvidia-detect.sh; then \
-	  cargo clean; \
-	  for path in `echo $$LD_LIBRARY_PATH | sed 's/:/ /g'`; do \
-	    libpaths="$$libpaths -L$$path"; \
-	  done; \
-	  $(CCFLAGS) RUSTFLAGS="$$libpaths -C link-arg=-s" cargo build --release $(CARGO_TARGET) --features nvidia; \
-	  mkdir -p build/$(TARGET_TYPE); \
-	  rm -f build/$(TARGET_TYPE)/zenith.nvidia; \
-	  install -m 755 target/$(TARGET_BUILDDIR)/zenith build/$(TARGET_TYPE)/zenith.nvidia; \
+	  $(MAKE) clean nvidia; \
 	fi
 
 base:
@@ -37,32 +38,58 @@ base:
 	rm -f build/$(TARGET_TYPE)/zenith.base
 	install -m 755 target/$(TARGET_BUILDDIR)/zenith build/$(TARGET_TYPE)/zenith.base
 
+nvidia:
+	@for path in `echo $$LD_LIBRARY_PATH | sed 's/:/ /g'`; do \
+	  libpaths="$$libpaths -L$$path"; \
+	done
+	$(CCFLAGS) RUSTFLAGS="$$libpaths -C link-arg=-s" cargo build --release $(CARGO_TARGET) --features nvidia
+	mkdir -p build/$(TARGET_TYPE)
+	rm -f build/$(TARGET_TYPE)/zenith.nvidia
+	install -m 755 target/$(TARGET_BUILDDIR)/zenith build/$(TARGET_TYPE)/zenith.nvidia
+
 clean:
 	cargo clean
 	rm -rf build
 	rm -f zenith.$(STATIC_TARGET).tgz*
 
 install:
-	@mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+	mkdir -p "$(DESTDIR)$(PREFIX)/bin"
 	@if [ -x build/$(TARGET_TYPE)/zenith.nvidia ]; then \
-	  mkdir -p "$(DESTDIR)$(PREFIX)/lib/zenith/base" "$(DESTDIR)$(PREFIX)/lib/zenith/nvidia"; \
-	  install -m 755 build/$(TARGET_TYPE)/zenith.base "$(DESTDIR)$(PREFIX)/lib/zenith/base/zenith"; \
-	  install -m 755 build/$(TARGET_TYPE)/zenith.nvidia "$(DESTDIR)$(PREFIX)/lib/zenith/nvidia/zenith"; \
-	  install -m 755 assets/zenith-libnvidia-detect.sh "$(DESTDIR)$(PREFIX)/lib/zenith/zenith-libnvidia-detect"; \
-	  install -m 755 assets/zenith.sh "$(DESTDIR)$(PREFIX)/bin/zenith"; \
-	  sed -i 's,PREFIX=/usr/local,PREFIX=$(PREFIX),' "$(DESTDIR)$(PREFIX)/bin/zenith"; \
+	  if [ -x build/$(TARGET_TYPE)/zenith.base ]; then \
+	    $(MAKE) install-both; \
+	  else \
+	    $(MAKE) install-nvidia; \
+	  fi \
 	else \
-	  install -m 755 build/$(TARGET_TYPE)/zenith.base "$(DESTDIR)$(PREFIX)/bin/zenith"; \
+	  $(MAKE) install-base; \
 	fi
 	@if [ $(UNAME) = "Linux" ]; then \
-	  mkdir -p "$(DESTDIR)$(PREFIX)/share/applications" "$(DESTDIR)$(PREFIX)/share/pixmaps"; \
-	  install -m 644 assets/zenith.png "$(DESTDIR)$(PREFIX)/share/pixmaps/zenith.png"; \
-	  install -m 644 assets/zenith.desktop "$(DESTDIR)$(PREFIX)/share/applications/zenith.desktop"; \
+	  $(MAKE) install-desktop; \
 	fi
+
+install-base:
+	install -m 755 build/$(TARGET_TYPE)/zenith.base "$(DESTDIR)$(PREFIX)/bin/zenith"
+
+install-nvidia:
+	install -m 755 build/$(TARGET_TYPE)/zenith.nvidia "$(DESTDIR)$(PREFIX)/bin/zenith"
+
+install-both:
+	mkdir -p "$(DESTDIR)$(PREFIX)/lib/zenith/base" "$(DESTDIR)$(PREFIX)/lib/zenith/nvidia"
+	install -m 755 build/$(TARGET_TYPE)/zenith.base "$(DESTDIR)$(PREFIX)/lib/zenith/base/zenith"
+	install -m 755 build/$(TARGET_TYPE)/zenith.nvidia "$(DESTDIR)$(PREFIX)/lib/zenith/nvidia/zenith"
+	install -m 755 assets/zenith-libnvidia-detect.sh "$(DESTDIR)$(PREFIX)/lib/zenith/zenith-libnvidia-detect"
+	install -m 755 assets/zenith.sh "$(DESTDIR)$(PREFIX)/bin/zenith"
+	sed -i 's,PREFIX=/usr/local,PREFIX=$(PREFIX),' "$(DESTDIR)$(PREFIX)/bin/zenith"
+
+install-desktop:
+	mkdir -p "$(DESTDIR)$(PREFIX)/share/applications" "$(DESTDIR)$(PREFIX)/share/pixmaps"
+	install -m 644 assets/zenith.png "$(DESTDIR)$(PREFIX)/share/pixmaps/zenith.png"
+	install -m 644 assets/zenith.desktop "$(DESTDIR)$(PREFIX)/share/applications/zenith.desktop"
 
 uninstall:
 	rm -rf "$(DESTDIR)$(PREFIX)/lib/zenith" "$(DESTDIR)$(PREFIX)/bin/zenith"
 	rm -f "$(DESTDIR)$(PREFIX)/share/pixmaps/zenith.png" "$(DESTDIR)$(PREFIX)/share/applications/zenith.desktop"
+	@rmdir "$(DESTDIR)$(PREFIX)/bin" "$(DESTDIR)$(PREFIX)/lib" "$(DESTDIR)$(PREFIX)/share/applications" "$(DESTDIR)$(PREFIX)/share/pixmaps" "$(DESTDIR)$(PREFIX)/share" 2>/dev/null || /bin/true
 
 linux-static-init:
 	rustup target add $(STATIC_TARGET)

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ deb [arch=amd64] https://dl.bintray.com/bvaisvil/debian stable main
 Then you can install/update the 'zenith' package:
 
 ```bash
-apt-get update
-apt-get install zenith
+sudo apt-get update
+sudo apt-get install zenith
 ```
 
 ### Arch Linux
 
 Three packages for zenith are available in AUR: zenith, zenith-git and zenith-bin
 
-The last one uses the statically linked binary and is not recommended unless you want to completely avoid building the package. The first two depend on rust/cargo and its recommended to install the rustup package from AUR instead of the rust package from official repositories. This allows for easy installation of rust components as per what rust officially documents. You will need to install a toolchain separately with rustup so use something like:
+The zenith-bin package uses the deb package mentioned in previous section and can be used to avoid building the package from source. The first two depend on rust/cargo and it is recommended to install the rustup package from AUR instead of the rust package from official repositories. This allows for easy installation of rust components as per what rust officially documents. You will need to install a toolchain separately with rustup so use something like:
 
 ```bash
 yay -S rustup
@@ -80,7 +80,7 @@ rustup toolchain install stable
 rustup default stable
 ```
 
-Change the 'stable' toolchain above to beta/nightly/... if you have some specific preference. After this install the zenith or zenith-git package (latter will always track the latest git revision): ```yay -S zenith```
+Change the 'stable' toolchain above to beta/nightly/... if you have some specific preference. After this install the zenith or zenith-git package (latter will track the latest git revision): ```yay -S zenith```
 
 ### Homebrew
 
@@ -104,14 +104,13 @@ For NVIDIA GPU support, build with feature `nvidia`:
 The minimum supported NVIDIA driver version is 418.56
 
 There is also a Makefile that detects the presence of NVIDIA driver on the
-current system and installs both the above flavours on Linux with a wrapper
-script to choose the appropriate one at runtime.
+current system and builds the appropriate flavor on Linux.
 
 ```make && sudo make install```
 
 If for some reason the Makefile incorrectly detects NVIDIA driver installation
 or in case of a broken installation (e.g. libnvidia-ml.so.1 present but no
-    libnvidia-ml.so) then explicitly skip it using the `base` target:
+libnvidia-ml.so) then explicitly skip it using the `base` target:
 
 ```make base && sudo make install```
 
@@ -119,6 +118,10 @@ The default installation path is `/usr/local` so `make install` requires root
 privileges above. To install in a custom location use PREFIX like below:
 
 ```make && make install PREFIX=$HOME/zenith```
+
+There is also an 'all' target in the Makefile that will build both the flavors on Linux,
+if NVIDIA driver is detected, and 'make install' will then copy a wrapper 'zenith' script
+that chooses the appropriate binary at runtime.
 
 ### Static build
 

--- a/debian/rules
+++ b/debian/rules
@@ -3,5 +3,8 @@
 %:
 	dh $@
 
+override_dh_auto_build:
+	dh_auto_build -- all
+
 override_dh_auto_install:
 	dh_auto_install -- PREFIX=/usr


### PR DESCRIPTION
Added a 'platform' target in Makefile (which is now the default) that will build only the platform-specific zenith binary by default i.e. NVIDIA enabled binary if NVIDIA driver detected else the basic binary. The previous 'all' target in Makefile will continue to build both flavors if possible but is no longer the default make target.

Debian package make target uses 'all' since runtime platform can be different from the one at build time (latter should be built with NVIDIA support).
