### PR TITLE
Fix length computation of top titlebar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,9 +1365,9 @@ checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -1487,5 +1487,6 @@ dependencies = [
  "signal-hook",
  "sysinfo",
  "tui",
+ "unicode-width",
  "users",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ log = "0.4.14"
 env_logger = { version = "0.9", default-features = false }
 libc = "0.2"
 nvml-wrapper = { version = "0.7.0", optional = true }
+unicode-width = "0.1.9"

--- a/src/render.rs
+++ b/src/render.rs
@@ -38,6 +38,7 @@ use tui::widgets::{
     BarChart, Block, Borders, List, ListItem, ListState, Paragraph, Row, Sparkline, Table, Wrap,
 };
 use tui::Frame;
+use unicode_width::UnicodeWidthStr;
 
 const PROCESS_SELECTION_GRACE: Duration = Duration::from_millis(2000);
 const LEFT_PANE_WIDTH: u16 = 34u16;
@@ -1357,7 +1358,7 @@ fn render_top_title_bar(
         Span::styled(" (q)uit", default_style),
     ];
 
-    let used_width: usize = line.iter().map(|s| s.content.len()).sum();
+    let used_width: usize = line.iter().map(|s| s.content.width()).sum();
     line.push(Span::styled(
         format!(
             "{:>width$}",


### PR DESCRIPTION
Previously, length was computed using bytes instead of graphemes.
This resulted in a too short length when unicode characters are used
to represent battery state.