### PR TITLE
Fix compile on latest nightly

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -2018,7 +2018,7 @@ impl<'a> TerminalRenderer<'_> {
                         let v_sections = Layout::default()
                             .direction(Direction::Vertical)
                             .margin(0)
-                            .constraints(constraints.as_ref())
+                            .constraints(constraints.as_slice())
                             .split(f.size());
 
                         render_top_title_bar(app, v_sections[0], f, zf, offset);


### PR DESCRIPTION
On nightly, slice has two `AsRef` impls, one for `[T]`, and one for `Vec<T>`. This change makes the program compile on nightly.

Here is the error before the change:
```
error[E0283]: type annotations needed
    --> src/render.rs:2021:54
     |
2021 | ...                   .constraints(constraints.as_ref())
     |                                    ------------^^^^^^--
     |                                    |           |
     |                                    |           cannot infer type for type parameter `T` declared on the trait `AsRef`
     |                                    this method call resolves to `&T`
     |
     = note: multiple `impl`s satisfying `Vec<Constraint>: AsRef<_>` found in the `alloc` crate:
             - impl<T, A> AsRef<Vec<T, A>> for Vec<T, A>
               where A: Allocator;
             - impl<T, A> AsRef<[T]> for Vec<T, A>
               where A: Allocator;
help: use the fully qualified path for the potential candidates
     |
2021 |                             .constraints(<Vec<T, A> as AsRef<Vec<T, A>>>::as_ref(constraints))
     |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2021 |                             .constraints(<Vec<T, A> as AsRef<[T]>>::as_ref(constraints))
     |                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

For more information about this error, try `rustc --explain E0283`.
error: could not compile `zenith` due to previous error
```