### PR TITLE
Remove unused `mut`

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -660,7 +660,7 @@ impl CPUTimeApp {
                 }
             }
             let name = get_device_name(d.get_name());
-            let mut zd = self.disks.entry(name).or_insert(ZDisk::from_disk(&d));
+            let zd = self.disks.entry(name).or_insert(ZDisk::from_disk(&d));
             zd.size_bytes = d.get_total_space();
             zd.available_bytes = d.get_available_space();
             total_available += zd.available_bytes;
@@ -725,7 +725,7 @@ impl CPUTimeApp {
         previous_io: IoMetrics,
         current_io: IoMetrics,
     ) {
-        let mut overall = self
+        let overall = self
             .disks
             .entry("Total".to_string())
             .or_insert(ZDisk::new_total());


### PR DESCRIPTION
FYI I'm not sure if this is correct or not, but cargo told me to submit this fix:

```rust
warning: variable does not need to be mutable
   --> src/metrics/mod.rs:663:17
    |
663 | ...   let mut zd = self.disks.entry(name).or_insert(ZDisk::fro...
    |           ----^^
    |           |
    |           help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: variable does not need to be mutable
   --> src/metrics/mod.rs:728:13
    |
728 |         let mut overall = self
    |             ----^^^^^^^
    |             |
    |             help: remove this `mut`

```