### PR TITLE
Fix for Issue 153

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,13 +31,13 @@ use std::error::Error;
 use std::fs;
 use std::io::stdout;
 use std::panic;
-use std::panic::PanicInfo;
+use std::panic::PanicHookInfo;
 use std::path::Path;
 use std::process::exit;
 use std::time::Duration;
 use std::time::SystemTime;
 
-fn panic_hook(info: &PanicInfo<'_>) {
+fn panic_hook(info: &PanicHookInfo<'_>) {
     let location = info.location().unwrap(); // The current implementation always returns Some
     let msg = match info.payload().downcast_ref::<&'static str>() {
         Some(s) => *s,

--- a/src/metrics/graphics/device.rs
+++ b/src/metrics/graphics/device.rs
@@ -4,10 +4,12 @@
 
 pub trait GraphicsExt {
     fn update_gfx_devices(&mut self);
+    #[allow(dead_code)]
     fn update_total(&mut self, total: Option<GraphicsDevice>);
     fn update_gpu_utilization(&mut self);
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct GraphicsDeviceProcess {
     pub pid: i32,

--- a/src/metrics/graphics/graphics_none.rs
+++ b/src/metrics/graphics/graphics_none.rs
@@ -7,6 +7,7 @@ use crate::metrics::CPUTimeApp;
 
 impl GraphicsExt for CPUTimeApp {
     fn update_gfx_devices(&mut self) {}
+    #[allow(unused_variables, unused_mut)]
     fn update_total(&mut self, mut total: Option<GraphicsDevice>) {}
     fn update_gpu_utilization(&mut self) {}
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -220,6 +220,7 @@ impl Top {
     }
 }
 
+#[allow(dead_code)]
 pub struct CPUTimeApp {
     pub histogram_map: HistogramMap,
     pub cpu_utilization: u64,

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -117,6 +117,7 @@ pub enum ProcessTableSortOrder {
 }
 
 pub trait DiskFreeSpaceExt {
+    #[allow(dead_code)]
     fn get_perc_free_space(&self) -> f32;
 }
 
@@ -128,13 +129,13 @@ impl DiskFreeSpaceExt for Disk {
         percent_of(self.get_available_space(), self.get_total_space())
     }
 }
-
+#[allow(dead_code)]
 pub struct NetworkInterface {
     pub name: String,
     pub ip: String,
     pub dest: String,
 }
-
+#[allow(dead_code)]
 pub struct Sensor {
     pub name: String,
     pub current_temp: f32,

--- a/src/metrics/zprocess.rs
+++ b/src/metrics/zprocess.rs
@@ -41,6 +41,7 @@ macro_rules! convert_error_to_string {
     };
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct ZProcess {
     pub pid: i32,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -248,7 +248,11 @@ impl<'a> TerminalRenderer<'_> {
         let mut section_geometry = section_geometry.to_vec();
         let mut recompute_constraints_on_start_up = false;
         app.update_gfx_devices();
-        if app.gfx_devices.is_empty() {
+        if app.gfx_devices.is_empty()
+            && section_geometry
+                .iter()
+                .any(|(s, _)| *s == Section::Graphics)
+        {
             section_geometry.retain(|(section, _)| *section != Section::Graphics);
             recompute_constraints_on_start_up = true;
         }


### PR DESCRIPTION
The users preferences were being ignored on systems without GPUs because the section heights would be recomputed to consider the absence of a graphics section. This PR checks to see if the graphics section exists in the layout. If it does, then we will need to recompute the layout considering it's absence, otherwise we do not.

This restores listening to the users preferences for dimensions of the sections.