### PR TITLE
fix: `3 warnings` generated by `bin "zenith"`

### DIFF
--- a/src/metrics/histogram.rs
+++ b/src/metrics/histogram.rs
@@ -191,7 +191,7 @@ impl HistogramMap {
         })
     }
 
-    pub fn get(&self, name: &HistogramKind) -> Option<&Histogram> {
+    pub fn get(&'_ self, name: &HistogramKind) -> Option<&'_ Histogram<'_>> {
         self.map.get(name)
     }
 

--- a/src/renderer/cpu.rs
+++ b/src/renderer/cpu.rs
@@ -92,7 +92,7 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
     ])
 }
 
-fn mem_title(app: &CPUTimeApp) -> Line {
+fn mem_title(app: &'_ CPUTimeApp) -> Line<'_> {
     let mem = percent_of(app.mem_utilization, app.mem_total) as u64;
     let swp = percent_of(app.swap_utilization, app.swap_total) as u64;
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -221,10 +221,10 @@ pub struct TerminalRenderer<'a> {
 impl<'a> TerminalRenderer<'_> {
     pub fn new(
         tick_rate: u64,
-        section_geometry: &[(Section, f64)],
+        section_geometry: &'_ [(Section, f64)],
         db_path: Option<PathBuf>,
         disable_history: bool,
-    ) -> TerminalRenderer {
+    ) -> TerminalRenderer<'_> {
         debug!("Create Metrics App");
         let mut app = CPUTimeApp::new(Duration::from_millis(tick_rate), db_path);
         debug!("Create Event Loop");


### PR DESCRIPTION
Fixes #173