### PR TITLE
Add peak tracking for processes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,55 @@
+# Pull Request
+
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature / enhancement
+- [ ] Performance improvement
+- [ ] Refactor (no behavior change)
+- [ ] Documentation
+- [ ] CI / tooling
+
+## Related Issue
+
+Closes # <!-- issue number, or "N/A" -->
+
+## Changes
+
+<!-- Bullet list of notable changes. Focus on the *what*, not the *how*. -->
+
+-
+-
+
+## Testing
+
+<!-- Describe how you tested this. Include platforms if relevant. -->
+
+**Platforms tested:**
+- [ ] Linux
+- [ ] macOS
+- [ ] Other: ___
+
+**Test steps:**
+
+1.
+2.
+
+## Performance Impact
+
+<!-- If this touches rendering, metrics collection, or data structures, note any perf implications.
+     Include before/after flamegraph or benchmark numbers if available. -->
+
+N/A
+
+## Checklist
+
+- [ ] `cargo clippy` passes with no new warnings
+- [ ] `cargo test` passes
+- [ ] `cargo fmt` applied
+- [ ] No new `unwrap()`/`expect()` without justification in a comment
+- [ ] non-obvious logic have doc comments
+- [ ] CHANGELOG updated (if user-facing change)

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -523,6 +523,16 @@ impl CPUTimeApp {
 
                     set_addl_task_info(zp);
 
+                    // Update peak values
+                    zp.peak_cpu_usage = zp.peak_cpu_usage.max(zp.cpu_usage);
+                    zp.peak_memory = zp.peak_memory.max(zp.memory);
+                    let read_rate = zp.get_read_bytes_sec(&self.histogram_map.tick);
+                    let write_rate = zp.get_write_bytes_sec(&self.histogram_map.tick);
+                    zp.peak_read_bytes_sec = zp.peak_read_bytes_sec.max(read_rate);
+                    zp.peak_write_bytes_sec = zp.peak_write_bytes_sec.max(write_rate);
+                    zp.peak_gpu_usage = zp.peak_gpu_usage.max(zp.gpu_usage);
+                    zp.peak_fb_utilization = zp.peak_fb_utilization.max(zp.fb_utilization);
+
                     top.update(zp, &self.histogram_map.tick);
                 } else {
                     let uid = process.user_id().map(|uid| **uid).unwrap_or(0);

--- a/src/metrics/zprocess.rs
+++ b/src/metrics/zprocess.rs
@@ -157,6 +157,12 @@ pub struct ZProcess {
     pub swap_delay: Duration,
     pub prev_io_delay: Duration,
     pub prev_swap_delay: Duration,
+    pub peak_cpu_usage: f32,
+    pub peak_memory: u64,
+    pub peak_read_bytes_sec: f64,
+    pub peak_write_bytes_sec: f64,
+    pub peak_gpu_usage: u64,
+    pub peak_fb_utilization: u64,
 }
 
 #[cfg(target_os = "macos")]
@@ -228,6 +234,12 @@ impl ZProcess {
             swap_delay: Duration::from_nanos(0),
             prev_io_delay: Duration::from_nanos(0),
             prev_swap_delay: Duration::from_nanos(0),
+            peak_cpu_usage: process.cpu_usage(),
+            peak_memory: process.memory(),
+            peak_read_bytes_sec: 0.0,
+            peak_write_bytes_sec: 0.0,
+            peak_gpu_usage: 0,
+            peak_fb_utilization: 0,
         };
         set_addl_task_info(&mut zp);
 

--- a/src/renderer/process.rs
+++ b/src/renderer/process.rs
@@ -355,7 +355,13 @@ pub fn render_process(
         ]),
         Line::from(vec![
             Span::raw("CPU Usage:             "),
-            Span::styled(format!("{:>7.2} %", &p.cpu_usage), rhs_style),
+            Span::styled(
+                format!(
+                    "{:>7.2} %  (Peak: {:>7.2} %)",
+                    &p.cpu_usage, &p.peak_cpu_usage
+                ),
+                rhs_style,
+            ),
         ]),
         Line::from(vec![
             Span::raw("Threads:               "),
@@ -376,7 +382,11 @@ pub fn render_process(
         Line::from(vec![
             Span::raw("MEM Usage:             "),
             Span::styled(
-                format!("{:>7.2} %", percent_of(p.memory, app.mem_total)),
+                format!(
+                    "{:>7.2} %  (Peak: {:>10})",
+                    percent_of(p.memory, app.mem_total),
+                    float_to_byte_string!(p.peak_memory as f64, Unit::B)
+                ),
                 rhs_style,
             ),
         ]),
@@ -391,9 +401,10 @@ pub fn render_process(
             Span::raw("Disk Read:             "),
             Span::styled(
                 format!(
-                    "{:>10} {:}/s",
+                    "{:>10} {:}/s  (Peak: {:}/s)",
                     float_to_byte_string!(p.read_bytes as f64, Unit::B),
-                    float_to_byte_string!(p.get_read_bytes_sec(&app.histogram_map.tick), Unit::B)
+                    float_to_byte_string!(p.get_read_bytes_sec(&app.histogram_map.tick), Unit::B),
+                    float_to_byte_string!(p.peak_read_bytes_sec, Unit::B)
                 ),
                 rhs_style,
             ),
@@ -402,9 +413,10 @@ pub fn render_process(
             Span::raw("Disk Write:            "),
             Span::styled(
                 format!(
-                    "{:>10} {:}/s",
+                    "{:>10} {:}/s  (Peak: {:}/s)",
                     float_to_byte_string!(p.write_bytes as f64, Unit::B),
-                    float_to_byte_string!(p.get_write_bytes_sec(&app.histogram_map.tick), Unit::B)
+                    float_to_byte_string!(p.get_write_bytes_sec(&app.histogram_map.tick), Unit::B),
+                    float_to_byte_string!(p.peak_write_bytes_sec, Unit::B)
                 ),
                 rhs_style,
             ),
@@ -418,7 +430,13 @@ pub fn render_process(
         ]));
         text.push(Line::from(vec![
             Span::raw("Frame Buffer:       "),
-            Span::styled(format!("{:7.2} %", p.fb_utilization as f64), rhs_style),
+            Span::styled(
+                format!(
+                    "{:7.2} %  (Peak: {:7.2} %)",
+                    p.fb_utilization as f64, p.peak_fb_utilization as f64
+                ),
+                rhs_style,
+            ),
         ]));
         text.push(Line::from(vec![
             Span::raw("Encoder Util:       "),
@@ -427,6 +445,16 @@ pub fn render_process(
         text.push(Line::from(vec![
             Span::raw("Decoder Util:       "),
             Span::styled(format!("{:7.2} %", p.dec_utilization as f64), rhs_style),
+        ]));
+        text.push(Line::from(vec![
+            Span::raw("GPU Usage:          "),
+            Span::styled(
+                format!(
+                    "{:7.2} %  (Peak: {:7.2} %)",
+                    p.gpu_usage as f64, p.peak_gpu_usage as f64
+                ),
+                rhs_style,
+            ),
         ]));
     }
 


### PR DESCRIPTION


## Summary

Adds tracking of peak values when examining a process. Useful for tracing a specific process.

## Type of Change

- [ ] Bug fix
- [x] New feature / enhancement
- [ ] Performance improvement
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling

## Changes

- Added Peak tracking to the process focus view
- 
## Testing

Tested on MacOS & Linux.

**Platforms tested:**
- [x] Linux
- [x] macOS
- [ ] Other: ___

**Test steps:**

1. Ran on macos & linux, values were indeed tracked.
2.

## Performance Impact

<!-- If this touches rendering, metrics collection, or data structures, note any perf implications.
     Include before/after flamegraph or benchmark numbers if available. -->

N/A

## Checklist

- [x] `cargo clippy` passes with no new warnings
- [x] `cargo test` passes
- [x] `cargo fmt` applied
- [x] No new `unwrap()`/`expect()` without justification in a comment
- [x] non-obvious logic have doc comments
