### PR TITLE
Fix show temp

### DIFF
--- a/src/renderer/cpu.rs
+++ b/src/renderer/cpu.rs
@@ -36,7 +36,10 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         0 => 0,
         _ => histogram.iter().max().unwrap_or(&0).to_owned(),
     };
-    let temp = if !app.sensors.is_empty() {
+    //let temp = if !app.sensors.is_empty() {
+    // Build TEMP spans conditionally - if no sensors, returns empty vec
+    // so "TEMP []" doesn't appear in the title bar
+    let temp_spans: Vec<Span> = if !app.sensors.is_empty() {
         let t = app
             .sensors
             .iter()
@@ -53,17 +56,55 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
             .map(|s| s.current_temp as f64)
             .fold(f64::MIN, f64::max);
 
-        if max_temp > hot_threshold {
+        //if max_temp > hot_threshold {
+        // Style the temperature number based on how hot it is
+        let colored = if max_temp > hot_threshold {
             Span::styled(numbers_txt, max_style())
         } else if max_temp < cold_threshold {
             Span::styled(numbers_txt, Style::default().fg(Color::Cyan))
         } else {
             Span::raw(numbers_txt)
-        }
+        };
+        
+        // Return all three spans so brackets only appear when there are sensors
+        vec![Span::raw(" TEMP ["), colored, Span::raw("]")]
     } else {
-        Span::raw(String::from(""))
+        //Span::raw(String::from(""))
+        vec![]
     };
-    Line::from(vec![
+
+    // Build the title spans incrementally so TEMP section can be
+    // conditionally included via extend
+    let mut spans = vec![
+        Span::raw("CPU ["),
+        Span::styled(
+            format!("{: >3}%", app.cpu_utilization),
+            if app.cpu_utilization > 90 {
+                max_style()
+            } else {
+                ok_style()
+            },
+        ),
+        Span::raw("]"),
+    ];
+    spans.extend(temp_spans);
+    spans.extend([
+        Span::raw(" MEAN ["),
+        Span::styled(
+            format!("{mean: >3.2}%"),
+            if mean > 90.0 { max_style() } else { ok_style() },
+        ),
+        Span::raw("] PEAK ["),
+        Span::styled(
+            format!("{peak: >3.2}%"),
+            if peak > 90 { max_style() } else { ok_style() },
+        ),
+        Span::raw(format!(
+            "] TOP [{top_pid} - {top_process_name} - {top_process_amt}]"
+        )),
+    ]);
+    Line::from(spans)
+    /*Line::from(vec![
         Span::raw("CPU ["),
         Span::styled(
             format!("{: >3}%", app.cpu_utilization),
@@ -90,7 +131,7 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         Span::raw(format!(
             "] TOP [{top_pid} - {top_process_name} - {top_process_amt}]"
         )),
-    ])
+    ])*/
 }
 
 fn mem_title(app: &'_ CPUTimeApp) -> Line<'_> {

--- a/src/renderer/cpu.rs
+++ b/src/renderer/cpu.rs
@@ -84,7 +84,9 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         ),
         Span::raw("]"),
     ];
-    spans.extend(temp_spans);
+    if !temp_spans.is_empty() {
+        spans.extend(temp_spans);
+    }
     spans.extend([
         Span::raw(" MEAN ["),
         Span::styled(

--- a/src/renderer/cpu.rs
+++ b/src/renderer/cpu.rs
@@ -63,7 +63,7 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         } else {
             Span::raw(numbers_txt)
         };
-        
+
         // Return all three spans so brackets only appear when there are sensors
         vec![Span::raw(" TEMP ["), colored, Span::raw("]")]
     } else {

--- a/src/renderer/cpu.rs
+++ b/src/renderer/cpu.rs
@@ -36,7 +36,6 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         0 => 0,
         _ => histogram.iter().max().unwrap_or(&0).to_owned(),
     };
-    //let temp = if !app.sensors.is_empty() {
     // Build TEMP spans conditionally - if no sensors, returns empty vec
     // so "TEMP []" doesn't appear in the title bar
     let temp_spans: Vec<Span> = if !app.sensors.is_empty() {
@@ -56,7 +55,6 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
             .map(|s| s.current_temp as f64)
             .fold(f64::MIN, f64::max);
 
-        //if max_temp > hot_threshold {
         // Style the temperature number based on how hot it is
         let colored = if max_temp > hot_threshold {
             Span::styled(numbers_txt, max_style())
@@ -69,7 +67,6 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         // Return all three spans so brackets only appear when there are sensors
         vec![Span::raw(" TEMP ["), colored, Span::raw("]")]
     } else {
-        //Span::raw(String::from(""))
         vec![]
     };
 
@@ -104,34 +101,6 @@ fn cpu_title<'a>(app: &'a CPUTimeApp, histogram: &'a [u64]) -> Line<'a> {
         )),
     ]);
     Line::from(spans)
-    /*Line::from(vec![
-        Span::raw("CPU ["),
-        Span::styled(
-            format!("{: >3}%", app.cpu_utilization),
-            if app.cpu_utilization > 90 {
-                max_style()
-            } else {
-                ok_style()
-            },
-        ),
-        Span::raw("]"),
-        Span::raw(" TEMP ["),
-        temp,
-        Span::raw("]"),
-        Span::raw(" MEAN ["),
-        Span::styled(
-            format!("{mean: >3.2}%",),
-            if mean > 90.0 { max_style() } else { ok_style() },
-        ),
-        Span::raw("] PEAK ["),
-        Span::styled(
-            format!("{peak: >3.2}%",),
-            if peak > 90 { max_style() } else { ok_style() },
-        ),
-        Span::raw(format!(
-            "] TOP [{top_pid} - {top_process_name} - {top_process_amt}]"
-        )),
-    ])*/
 }
 
 fn mem_title(app: &'_ CPUTimeApp) -> Line<'_> {


### PR DESCRIPTION
# Pull Request

## Summary
Fix CPU title bar showing "TEMP []" when no temperature sensors are present. 
The TEMP section is now fully hidden when there are no sensors.

<!-- One or two sentences describing what this PR does and why. -->

## Type of Change

- [**X**] Bug fix
- [ ] New feature / enhancement
- [ ] Performance improvement
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] CI / tooling

## Related Issue

Closes # <!-- issue number, or "N/A" -->

## Changes

<!-- Bullet list of notable changes. Focus on the *what*, not the *how*. -->

- Changed `temp` from a single `Span` to a `Vec<Span>` (`temp_spans`) that 
is conditionally populated. This returns all three spans (label, value, 
closing bracket) only when sensors exist, and an empty vec otherwise. 
- The title line is now built incrementally using `extend` so the TEMP 
section is completely absent when there are no sensors.

## Testing

<!-- Describe how you tested this. Include platforms if relevant. -->
Previously, the CPU sparkline title bar would render "TEMP []" even when 
no sensors were available, which looked wrong.

**Platforms tested:**
- [ ] Linux
- [**X**] macOS
- [ ] Other: ___

**Test steps:**

1. Ran 'cargo run'
2. TEMP[] no longer shows when there are no sensors detected.

## Performance Impact

<!-- If this touches rendering, metrics collection, or data structures, note any perf implications.
     Include before/after flamegraph or benchmark numbers if available. -->

N/A

## Checklist

- [ ] `cargo clippy` passes with no new warnings
- [**X**] `cargo test` passes
- [ ] `cargo fmt` applied
- [ ] No new `unwrap()`/`expect()` without justification in a comment
- [ ] non-obvious logic have doc comments
- [ ] CHANGELOG updated (if user-facing change)
