### PR TITLE
fix: correct Unkown→Unknown typo in NVIDIA error message

### DIFF
--- a/src/renderer/help.rs
+++ b/src/renderer/help.rs
@@ -102,7 +102,7 @@ pub fn render_help(
         let content = match ne {
             NvmlError::DriverNotLoaded => "NVIDIA Error: No Driver Detected.",
             NvmlError::NoPermission => "NVIDIA Error: Permissioned denied to talk to driver.",
-            NvmlError::Unknown => "NVIDIA Error: Unkown Error.",
+            NvmlError::Unknown => "NVIDIA Error: Unknown Error.",
             _ => "",
         };
         if !content.is_empty() {


### PR DESCRIPTION
Fixes a typo in src/renderer/help.rs where 'Unkown' should be 'Unknown' in an NVIDIA error message.

**Before:** `NvmlError::Unknown => "NVIDIA Error: Unkown Error."`
**After:** `NvmlError::Unknown => "NVIDIA Error: Unknown Error."`

1 line change. 1 commit.